### PR TITLE
Setting up broken content type test

### DIFF
--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersPage.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersPage.js
@@ -5,6 +5,10 @@ class HttpHeadersPage {
 			["Content-Security-Policy", "example.com"],
 		];
 	}
+
+	getContentType() {
+		return "application/httpheaderspage";
+	}
 }
 
 module.exports = HttpHeadersPage;

--- a/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
+++ b/packages/react-server-integration-tests/src/__tests__/httpHeaders/HttpHeadersSpec.js
@@ -9,7 +9,7 @@ describe('A page with custom http headers', () => {
 
 	helper.stopServerAfterAll();
 
-	describe('has sync rendered headers', () => {
+	fdescribe('has sync rendered headers', () => {
 		helper.testWithBrowser('/httpHeaders', (browser, isTransition) => {
 			expectSecurityPolicyHeaderExists(browser, isTransition);
 		});
@@ -28,7 +28,9 @@ describe('A page with custom http headers', () => {
 
 		const headers = browser.resources['0'].response.headers._headers;
 		const csp = headers.find(header => header[0] === 'content-security-policy');
+		const contentType = headers.find(header => header[0] === 'content-type');
 
 		expect(csp[1]).toBe("example.com");
+		expect(contentType[1]).toBe("application/httpheaderspage");
 	}
 });

--- a/packages/react-server/core/renderMiddleware.js
+++ b/packages/react-server/core/renderMiddleware.js
@@ -278,6 +278,7 @@ function pageLifecycle() {
 	return [
 		Q(), // This is just a NOOP lead-in to prime the reduction.
 		setHttpHeaders,
+		setContentType,
 		writeHeader,
 		startBody,
 		writeBody,

--- a/packages/react-server/core/util/PageUtil.js
+++ b/packages/react-server/core/util/PageUtil.js
@@ -50,7 +50,7 @@ var PAGE_MIXIN = {
 //
 var PAGE_METHODS = {
 	handleRoute        : [() => ({code: 200}), Q],
-	getContentType     : [() => "text/html; charset=utf-8", _ => _],
+	getContentType     : [() => "this is totes not html", _ => _],
 	getHeaders         : [() => [], Q],
 	getTitle           : [() => "", Q],
 	getScripts         : [() => [], standardizeScripts],


### PR DESCRIPTION
Tests to demonstrate that `getContentType()` is broken in the page lifecycle. This is the result of the tests:

```
Failures: 
1) A page with custom http headers has sync rendered headers on server
1.1) Expected 'text/html; charset=utf-8' to be 'application/httpheaderspage'.

2) A page with custom http headers has sync rendered headers on client
2.1) Expected 'text/html; charset=utf-8' to be 'application/httpheaderspage'.
```

So, it's not pulling in the page specified value nor the the PageUtil default.

However! If I remove `res.type('html');` from `writeHeader()`, the test passes. So that must be setting the content-type header. Which is exactly what express claims.

```
Sets the Content-Type HTTP header to the MIME type as determined by mime.lookup() for the specified type. If type contains the "/" character, then it sets the Content-Type to type.
```
